### PR TITLE
Enhance reward structure and training settings

### DIFF
--- a/blackjack_env.py
+++ b/blackjack_env.py
@@ -5,8 +5,6 @@ from player import Player
 from hand import Hand
 from constants import RESHUFFLE_THRESHOLD, AGENT_BANKROLL_TARGET, AGENT_STARTING_BANKROLL
 from agent_player import AgentPlayer
-import math
-from helpers import is_lambda
 from rewards import REWARDS_BINDINGS
 
 class BlackjackEnv:
@@ -148,15 +146,14 @@ class BlackjackEnv:
             reward = 0
             rules = []
             for reward_binding in REWARDS_BINDINGS:
-                if reward_binding.bool_function(self, player):
-                    temp_reward = 0
-                    if is_lambda(reward_binding.reward):
-                        temp_reward+=reward_binding.reward(self, player)
-                    else:
-                        temp_reward+=reward_binding.reward
-                    
-                    reward+=temp_reward
-                    rules.append(reward_binding.label + f" (reward: {temp_reward})")
+                if reward_binding.condition(self, player):
+                    value = (
+                        reward_binding.value(self, player)
+                        if callable(reward_binding.value)
+                        else reward_binding.value
+                    )
+                    reward += value
+                    rules.append(f"{reward_binding.label} (reward: {value})")
 
             print("")
             for rule in rules:

--- a/rewards.py
+++ b/rewards.py
@@ -1,67 +1,146 @@
+"""Reward definitions for agent training.
+
+This module defines small helper callables that evaluate the game state and
+assign scalar rewards.  The rewards are intentionally dense to provide more
+training signal than a simple win/loss outcome.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Union
+
 from constants import AGENT_STARTING_BANKROLL
 import math
+
+
+# ---------------------------------------------------------------------------
+# Reward container
+# ---------------------------------------------------------------------------
+
+@dataclass
 class Reward:
-    def __init__(self, label,reward, bool_function ):
-        self.label = label
-        self.bool_function = bool_function
-        self.reward=reward
+    """Container describing a training reward."""
+
+    label: str
+    value: Union[float, Callable]
+    condition: Callable[["BlackjackEnv", "AgentPlayer"], bool]
+
+
+# ---------------------------------------------------------------------------
+# Helper functions used by reward conditions/values
+# ---------------------------------------------------------------------------
+
+
+def _balance_change(env, player):
+    """Reward based on bankroll growth using a log scale."""
+    ratio = max(player.bankroll, 1) / AGENT_STARTING_BANKROLL
+    return max(-5.0, min(math.log(ratio), 5.0))
+
+
+def _agent_won(env, player):
+    """Return ``True`` if the agent won the round."""
+    hand = player.current_hand()
+    dealer = env.dealer.current_hand()
+    if hand.is_busted():
+        return False
+    dealer_val = dealer.get_values()
+    player_val = hand.get_values()
+    return dealer_val > 21 or player_val > dealer_val
+
+
+def _agent_push(env, player):
+    """Return ``True`` if the round resulted in a push."""
+    hand = player.current_hand()
+    dealer_val = env.dealer.current_hand().get_values()
+    return not hand.is_busted() and hand.get_values() == dealer_val
+
+
+# ---------------------------------------------------------------------------
+# Reward bindings
+# ---------------------------------------------------------------------------
 
 REWARDS_BINDINGS = [
-    #Reward(,,lambda env, player:),
-    Reward("Agent Hit on 21", -2, lambda env, player: not player.current_hand().is_blackjack() 
-                                                and player.current_hand().get_original_delt_values() == 21),
-    
-    #Reward("Agent has Blackjack", 2, lambda env, player: player.current_hand().is_blackjack()),
-    
-    Reward("Agent stood_below 17 and card showing was greater than 7",-5, lambda env, player: player.current_hand().stood_below_17 
-                                                                                    and env.dealer.current_hand().get_first_card_value() >= 7),
-    
-    Reward("Agent Hit above 17", -5,lambda env, player: player.current_hand().hit_above_17),
-    
-    Reward("Agent had a good double", 2,lambda env, player: player.current_hand().has_doubled 
-                                                    and player.current_hand().get_original_delt_values() <= 11 
-                                                    and player.current_hand().get_original_delt_values()>8 
-                                                    and env.dealer.current_hand().get_first_card_value() <= 8),
-    
-    Reward("Agent didnt bust but shouldnt have hit",-2,lambda env, player: player.current_hand().get_values() <=21 
-                                        and env.dealer.current_hand().hit_above_17),
-    
-    Reward("Agent didnt double when it should have",-5,lambda env, player: player.current_hand().get_original_delt_values()>= 8 
-                                                                and player.current_hand().get_original_delt_values() <= 11 
-                                                                and env.dealer.current_hand().get_first_card_value() < 8
-                                                                and not player.current_hand().has_doubled),
-    
-    Reward("Agent didnt hit when it was below 17 and dealer showing 7 or higher",-5,lambda env, player: env.dealer.current_hand().get_first_card_value() >= 7 
-                                                                                            and player.current_hand().get_values() < 17),
-    
-    Reward("Agent busted on a double",-5, lambda env, player: player.current_hand().has_doubled 
-                                                        and player.current_hand().is_busted()),
-    
-    Reward("Agent Doubled when hand had to high of value",-5,lambda env, player: player.current_hand().has_doubled 
-                                                                    and player.current_hand().get_original_delt_values() > 11
-                                                                    and not player.current_hand().ace_in_original_hand),
-    
-    Reward("Agent Hit when its hand was under 17 and dealer showing high card",2,lambda env, player: not player.current_hand().hit_above_17 
-                                                                                                and len(player.current_hand().cards)> 2
-                                                                                                and player.current_hand().get_original_delt_values()<= 11
-                                                                                                and env.dealer.current_hand().get_first_card_value()>= 7),
+    # Round outcome rewards
+    Reward("Agent has blackjack", 3, lambda env, player: player.current_hand().is_blackjack()),
+    Reward(
+        "Agent hit on 21",
+        -2,
+        lambda env, player: not player.current_hand().is_blackjack()
+        and player.current_hand().get_original_delt_values() == 21,
+    ),
+    Reward("Agent busted", -5, lambda env, player: player.current_hand().is_busted()),
+    Reward("Agent won round", 5, _agent_won),
+    Reward("Agent pushed round", 1, _agent_push),
+    Reward(
+        "Agent lost round",
+        -5,
+        lambda env, player: not _agent_won(env, player) and not _agent_push(env, player),
+    ),
+    Reward("Bankroll change", _balance_change, lambda env, player: True),
 
-    Reward("Agent stays on delt high cards",2,lambda env, player: len(player.current_hand().cards) == 2
-                                                                    and player.current_hand().get_values()>=17),
-
-    Reward("Agent stood when hand started with over 11 and dealer showing low card",2,lambda env, player: player.current_hand().get_values()>11
-                                                                    and len(player.current_hand().cards)> 2
-                                                                    and env.dealer.current_hand().get_first_card_value()<=6
-                                                                    and not player.current_hand().hit_above_17),
-
-    Reward("Agent doubled when original value was greater than 11",-5,lambda env, player: player.current_hand().has_doubled
-                                                                    and player.current_hand().get_original_delt_values()> 11
-                                                                    )                                                                                                                                         
-
-    #Reward("Agent Won round",2,lambda env, player: player.current_hand().get_values()<=21 
-    #                                            and (env.dealer.current_hand().get_values() < player.current_hand().get_values() 
-    #                                                 or env.dealer.current_hand().is_busted())),
-    
-    #Reward("Add rewards for balance changes", lambda env, player: max(-5, min(math.log(player.bankroll / AGENT_STARTING_BANKROLL), 5)), lambda env, player: True)
-    #Reward(,,lambda env, player:),
+    # Tactical play rewards/penalties
+    Reward(
+        "Agent stood below 17 against high dealer card",
+        -5,
+        lambda env, player: player.current_hand().stood_below_17
+        and env.dealer.current_hand().get_first_card_value() >= 7,
+    ),
+    Reward("Agent hit above 17", -5, lambda env, player: player.current_hand().hit_above_17),
+    Reward(
+        "Agent had a good double",
+        2,
+        lambda env, player: player.current_hand().has_doubled
+        and 8 < player.current_hand().get_original_delt_values() <= 11
+        and env.dealer.current_hand().get_first_card_value() <= 8,
+    ),
+    Reward(
+        "Agent didn't double when it should have",
+        -5,
+        lambda env, player: 8 <= player.current_hand().get_original_delt_values() <= 11
+        and env.dealer.current_hand().get_first_card_value() < 8
+        and not player.current_hand().has_doubled,
+    ),
+    Reward(
+        "Agent didn't hit vs high dealer card",
+        -5,
+        lambda env, player: env.dealer.current_hand().get_first_card_value() >= 7
+        and player.current_hand().get_values() < 17,
+    ),
+    Reward(
+        "Agent busted on a double",
+        -5,
+        lambda env, player: player.current_hand().has_doubled
+        and player.current_hand().is_busted(),
+    ),
+    Reward(
+        "Agent doubled with high starting value",
+        -5,
+        lambda env, player: player.current_hand().has_doubled
+        and player.current_hand().get_original_delt_values() > 11
+        and not player.current_hand().ace_in_original_hand,
+    ),
+    Reward(
+        "Agent hit correctly vs high dealer card",
+        2,
+        lambda env, player: not player.current_hand().hit_above_17
+        and len(player.current_hand().cards) > 2
+        and player.current_hand().get_original_delt_values() <= 11
+        and env.dealer.current_hand().get_first_card_value() >= 7,
+    ),
+    Reward(
+        "Agent stayed on dealt high cards",
+        2,
+        lambda env, player: len(player.current_hand().cards) == 2
+        and player.current_hand().get_values() >= 17,
+    ),
+    Reward(
+        "Agent stood after drawing above 11 with low dealer card",
+        2,
+        lambda env, player: player.current_hand().get_values() > 11
+        and len(player.current_hand().cards) > 2
+        and env.dealer.current_hand().get_first_card_value() <= 6
+        and not player.current_hand().hit_above_17,
+    ),
 ]
+

--- a/train_reinforce.py
+++ b/train_reinforce.py
@@ -7,9 +7,11 @@ from agent_player import AgentPlayer
 from blackjack_env import BlackjackEnv
 from torch.optim import Adam
 import os
+
 NUM_EPISODES = 100000
 SAVE_EVERY = 500
-EPSILON = 0.2
+EPSILON_START = 0.2
+EPSILON_END = 0.05
 LR = 1e-4
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 BATCH_SIZE = 128
@@ -27,11 +29,14 @@ elif agent is None:
 optimizer = Adam(agent.parameters(), lr=LR)
 
 win_count = 0
-player = AgentPlayer("Bot", agent=agent)
+player = AgentPlayer("Bot", agent=agent, epsilon=EPSILON_START)
 
 env = BlackjackEnv(player=player)
 
+epsilon_decay = (EPSILON_START - EPSILON_END) / NUM_EPISODES
+
 for episode in range(1, NUM_EPISODES + 1):
+    player.epsilon = max(EPSILON_END, EPSILON_START - (episode - 1) * epsilon_decay)
     env.reset()
     env.play_round()
 


### PR DESCRIPTION
## Summary
- refactor rewards into structured dataclass and add round outcome and bankroll-based incentives
- adjust environment to use new reward definitions
- add epsilon decay schedule and expose epsilon in training loop

## Testing
- `python -m py_compile rewards.py blackjack_env.py train_reinforce.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a86866b88320b80129bc9dcb90e9